### PR TITLE
Fix constants styling

### DIFF
--- a/templates/ClassPrototype.php.twig
+++ b/templates/ClassPrototype.php.twig
@@ -6,24 +6,21 @@ class {{ prototype.name }}{% if prototype.extendsClass.notNone %} extends {{ pro
 {
 {% for constant in prototype.constants %}
 {{ generator.render(constant, variant)|indent(1)|raw }}
-{% if not loop.last %}
-
-{% endif %}
 {% endfor %}
 {% for property in prototype.properties %}
+{% if loop.first and prototype.constants|length %}
+
+{% endif %}
 {{ generator.render(property, variant)|indent(1)|raw }}
 {% if not loop.last %}
 
 {% endif %}
 {% endfor %}
 {% for method in prototype.methods %}
-{% if loop.first and prototype.properties|length %}
+{% if prototype.properties|length or not loop.first %}
 
 {% endif %}
 {{ generator.render(method, variant)|indent(1)|raw }}
 {{ generator.render(method.body)|indent(1)|raw }}
-{% if not loop.last %}
-
-{% endif %}
 {% endfor %}
 }

--- a/tests/Adapter/GeneratorTestCase.php
+++ b/tests/Adapter/GeneratorTestCase.php
@@ -568,4 +568,53 @@ EOT
 
         $this->assertEquals($expected, (string) $code);
     }
+
+    public function testConstantsAndProperties()
+    {
+        $expected = <<<'EOT'
+<?php
+
+namespace Animals;
+
+interface Animal
+{
+    public function sleep();
+}
+
+class Rabbits implements Animal
+{
+    const LEGS = 4;
+    const SKIN = 'soft';
+
+    /**
+     * @var int
+     */
+    private $force = 5;
+
+    public $guile;
+}
+EOT
+        ;
+        $source = $builder = SourceCodeBuilder::create()
+            ->namespace('Animals')
+            ->class('Rabbits')
+                ->implements('Animal')
+                ->property('force')
+                    ->visibility('private')
+                    ->type('int')
+                    ->defaultValue(5)
+                ->end()
+                ->property('guile')->end()
+                ->constant('LEGS', 4)->end()
+                ->constant('SKIN', 'soft')->end()
+            ->end()
+            ->interface('Animal')
+                ->method('sleep')->end()
+            ->end()
+            ->build();
+
+        $code = $this->renderer()->render($source);
+
+        $this->assertEquals($expected, (string) $code);
+    }
 }


### PR DESCRIPTION
Removed empty lines between constants.
Added a test to check that constants are added the good way, before properties (Cf. https://github.com/phpactor/phpactor/issues/226 )