### PR TITLE
Update property generation for typed properties

### DIFF
--- a/lib/Adapter/TolerantParser/Updater/ClassLikeUpdater.php
+++ b/lib/Adapter/TolerantParser/Updater/ClassLikeUpdater.php
@@ -84,6 +84,14 @@ abstract class ClassLikeUpdater
             }
         }
 
+        // If the previous member is neither the open brace of class nor a property
+        // Then we must add a blank line before the new properties
+        if ($lastProperty !== $classMembers->openBrace
+            && !($lastProperty instanceof PropertyDeclaration)
+        ) {
+            $edits->after($lastProperty, PHP_EOL);
+        }
+
         foreach ($classPrototype->properties()->notIn($existingPropertyNames) as $property) {
             // if property type exists then the last property has a docblock - add a line break
             if ($lastProperty instanceof PropertyDeclaration && $property->type() != Type::none()) {

--- a/lib/Adapter/TolerantParser/Updater/ClassLikeUpdater.php
+++ b/lib/Adapter/TolerantParser/Updater/ClassLikeUpdater.php
@@ -11,7 +11,6 @@ use Microsoft\PhpParser\Node\PropertyDeclaration;
 use Microsoft\PhpParser\Node\TraitUseClause;
 use Phpactor\CodeBuilder\Adapter\TolerantParser\Edits;
 use Phpactor\CodeBuilder\Domain\Prototype\ClassLikePrototype;
-use Phpactor\CodeBuilder\Domain\Prototype\Type;
 use Phpactor\CodeBuilder\Domain\Renderer;
 
 abstract class ClassLikeUpdater
@@ -93,14 +92,15 @@ abstract class ClassLikeUpdater
         }
 
         foreach ($classPrototype->properties()->notIn($existingPropertyNames) as $property) {
-            $edits->after(
-                $lastProperty,
-                PHP_EOL . $edits->indent($this->renderer->render($property), 1)
-            );
+            $renderedProperty = $this->renderer->render($property);
 
-            if ($classPrototype->properties()->isLast($property) && $nextMember instanceof MethodDeclaration) {
-                $edits->after($lastProperty, PHP_EOL);
-            }
+            $edits->after($lastProperty, PHP_EOL . $edits->indent($renderedProperty, 1));
+        }
+
+        if ($lastProperty === $classMembers->openBrace &&
+            $nextMember instanceof MethodDeclaration
+        ) {
+            $edits->after($lastProperty, PHP_EOL);
         }
     }
 }

--- a/lib/Adapter/TolerantParser/Updater/ClassLikeUpdater.php
+++ b/lib/Adapter/TolerantParser/Updater/ClassLikeUpdater.php
@@ -58,14 +58,10 @@ abstract class ClassLikeUpdater
         $previousMember = $classMembers->openBrace;
         $memberDeclarations = $this->memberDeclarations($classMembers);
 
-        $nextMember = null;
+        $nextMember = reset($memberDeclarations) ?: null;
         $existingPropertyNames = [];
 
         foreach ($memberDeclarations as $memberNode) {
-            if (null === $nextMember) {
-                $nextMember = $memberNode;
-            }
-
             // Property goes after traits and constants
             if ($memberNode instanceof TraitUseClause ||
                 $memberNode instanceof ClassConstDeclaration

--- a/lib/Adapter/TolerantParser/Updater/ClassLikeUpdater.php
+++ b/lib/Adapter/TolerantParser/Updater/ClassLikeUpdater.php
@@ -3,10 +3,12 @@
 namespace Phpactor\CodeBuilder\Adapter\TolerantParser\Updater;
 
 use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\Node\ClassConstDeclaration;
 use Microsoft\PhpParser\Node\Expression\AssignmentExpression;
 use Microsoft\PhpParser\Node\Expression\Variable;
 use Microsoft\PhpParser\Node\MethodDeclaration;
 use Microsoft\PhpParser\Node\PropertyDeclaration;
+use Microsoft\PhpParser\Node\TraitUseClause;
 use Phpactor\CodeBuilder\Adapter\TolerantParser\Edits;
 use Phpactor\CodeBuilder\Domain\Prototype\ClassLikePrototype;
 use Phpactor\CodeBuilder\Domain\Prototype\Type;
@@ -63,6 +65,13 @@ abstract class ClassLikeUpdater
         foreach ($memberDeclarations as $memberNode) {
             if (null === $nextMember) {
                 $nextMember = $memberNode;
+            }
+
+            // Property goes after traits and constants
+            if ($memberNode instanceof TraitUseClause ||
+                $memberNode instanceof ClassConstDeclaration
+            ) {
+                $lastProperty = $memberNode;
             }
 
             if ($memberNode instanceof PropertyDeclaration) {

--- a/lib/Adapter/TolerantParser/Updater/ClassLikeUpdater.php
+++ b/lib/Adapter/TolerantParser/Updater/ClassLikeUpdater.php
@@ -93,11 +93,6 @@ abstract class ClassLikeUpdater
         }
 
         foreach ($classPrototype->properties()->notIn($existingPropertyNames) as $property) {
-            // if property type exists then the last property has a docblock - add a line break
-            if ($lastProperty instanceof PropertyDeclaration && $property->type() != Type::none()) {
-                $edits->after($lastProperty, PHP_EOL);
-            }
-
             $edits->after(
                 $lastProperty,
                 PHP_EOL . $edits->indent($this->renderer->render($property), 1)

--- a/lib/Adapter/WorseReflection/WorseBuilderFactory.php
+++ b/lib/Adapter/WorseReflection/WorseBuilderFactory.php
@@ -101,7 +101,9 @@ class WorseBuilderFactory implements BuilderFactory
         if ($method->returnType()->isDefined()) {
             $type = $method->returnType();
             $this->resolveClassMemberType($classBuilder, $method->class()->name(), $type);
-            $methodBuilder->returnType($type->short());
+            $imports = $method->scope()->nameImports();
+            $typeName = $this->resolveTypeNameFromNameImports($type, $imports);
+            $methodBuilder->returnType($typeName);
         }
 
         if ($method->isStatic()) {

--- a/lib/Adapter/WorseReflection/WorseBuilderFactory.php
+++ b/lib/Adapter/WorseReflection/WorseBuilderFactory.php
@@ -87,7 +87,9 @@ class WorseBuilderFactory implements BuilderFactory
         $type = $property->inferredTypes()->best();
         if ($type->isDefined()) {
             $this->resolveClassMemberType($classBuilder, $property->class()->name(), $type);
-            $propertyBuilder->type((string) $type->short());
+            $imports = $property->scope()->nameImports();
+            $typeName = $this->resolveTypeNameFromNameImports($type, $imports);
+            $propertyBuilder->type($typeName);
         }
     }
 
@@ -150,6 +152,11 @@ class WorseBuilderFactory implements BuilderFactory
                 $typeName = $alias;
             }
         }
+
+        if ($type->isNullable()) {
+            return "?$typeName";
+        }
+
         return $typeName;
     }
 }

--- a/lib/Util/TextFormat.php
+++ b/lib/Util/TextFormat.php
@@ -18,6 +18,10 @@ class TextFormat
     {
         $lines = explode(PHP_EOL, $string);
         $lines = array_map(function ($line) use ($level) {
+            if (empty($line)) {
+                return $line;
+            }
+
             return str_repeat($this->indentation, $level) . $line;
         }, $lines);
 

--- a/templates/Property.php.twig
+++ b/templates/Property.php.twig
@@ -1,4 +1,5 @@
 {% if prototype.type.notNone %}
+
 /**
  * @var {{ prototype.type }}
  */

--- a/templates/Property.php.twig
+++ b/templates/Property.php.twig
@@ -1,7 +1,7 @@
 {% if prototype.type.notNone %}
 
 /**
- * @var {{ prototype.type }}
+ * @var {{ prototype.type|trim('?', 'left') }}{{ prototype.type.nullable ? '|null' }}
  */
 {% endif %}
 {{ prototype.visibility }} ${{ prototype.name}}{% if prototype.defaultValue.notNone %} = {{ prototype.defaultValue.export }}{% endif %};

--- a/tests/Adapter/GeneratorTestCase.php
+++ b/tests/Adapter/GeneratorTestCase.php
@@ -359,6 +359,7 @@ EOT
                     Type::fromString('PlaneCollection')
                 ),
                 <<<'EOT'
+
 /**
  * @var PlaneCollection
  */
@@ -487,6 +488,7 @@ interface Animal
 
 trait Oryctolagus
 {
+
     /**
      * @var bool
      */
@@ -499,6 +501,7 @@ trait Oryctolagus
 
 class Rabbits extends Leporidae implements Animal
 {
+
     /**
      * @var int
      */
@@ -583,6 +586,7 @@ class Rabbits implements Animal
 {
     const LEGS = 4;
     const SKIN = 'soft';
+
 
     /**
      * @var int

--- a/tests/Adapter/UpdaterTestCase.php
+++ b/tests/Adapter/UpdaterTestCase.php
@@ -925,6 +925,7 @@ EOT
                 <<<'EOT'
 class Aardvark
 {
+
     /**
      * @var Hello
      */
@@ -1092,6 +1093,7 @@ EOT
                 <<<'EOT'
 trait Aardvark
 {
+
     /**
      * @var Hello
      */

--- a/tests/Adapter/UpdaterTestCase.php
+++ b/tests/Adapter/UpdaterTestCase.php
@@ -7,6 +7,7 @@ use Phpactor\CodeBuilder\Domain\Updater;
 use Phpactor\CodeBuilder\Domain\Code;
 use Phpactor\CodeBuilder\Domain\Builder\SourceCodeBuilder;
 use Phpactor\CodeBuilder\Domain\Prototype\SourceCode;
+use Phpactor\WorseReflection\Core\Type;
 
 abstract class UpdaterTestCase extends TestCase
 {
@@ -883,7 +884,7 @@ class Aardvark
 EOT
             ];
 
-        yield 'It adds a documented properties' => [
+        yield 'It adds a typed property' => [
                 <<<'EOT'
 class Aardvark
 {
@@ -902,6 +903,33 @@ class Aardvark
 
     /**
      * @var Hello
+     */
+    public $propertyOne;
+}
+EOT
+            ];
+
+        yield 'It adds a nullable typed property' => [
+                <<<'EOT'
+class Aardvark
+{
+    public $eyes
+}
+EOT
+                , SourceCodeBuilder::create()
+                    ->class('Aardvark')
+                        ->property('propertyOne')->type(
+                            Type::fromString('Hello')->asNullable()
+                        )->end()
+                    ->end()
+                    ->build(),
+                <<<'EOT'
+class Aardvark
+{
+    public $eyes
+
+    /**
+     * @var Hello|null
      */
     public $propertyOne;
 }

--- a/tests/Adapter/UpdaterTestCase.php
+++ b/tests/Adapter/UpdaterTestCase.php
@@ -1300,6 +1300,35 @@ class Aardvark
 EOT
             ];
 
+        yield 'It adds nullable typed parameters' => [
+                <<<'EOT'
+class Aardvark
+{
+    public function methodOne()
+    {
+    }
+}
+EOT
+                , SourceCodeBuilder::create()
+                    ->class('Aardvark')
+                        ->method('methodOne')
+                            ->parameter('sniff')->type(
+                                Type::fromString('Barf')->asNullable()
+                            )
+                            ->end()
+                        ->end()
+                    ->end()
+                    ->build(),
+                <<<'EOT'
+class Aardvark
+{
+    public function methodOne(?Barf $sniff)
+    {
+    }
+}
+EOT
+            ];
+
         yield 'It adds parameters and leaves existing ones in place' => [
                 <<<'EOT'
 class Aardvark

--- a/tests/Adapter/WorseReflection/WorseBuilderFactoryTest.php
+++ b/tests/Adapter/WorseReflection/WorseBuilderFactoryTest.php
@@ -72,6 +72,16 @@ class WorseBuilderFactoryTest extends TestCase
         $this->assertEquals('Bar\Foobar', (string) $source->useStatements()->first());
     }
 
+    public function testClassWithPropertyImportedNullableType()
+    {
+        $source = $this->build('<?php namespace Test; use Bar\Foobar; class Foobar { private ?Foobar $foo = "foobar"; }');
+        $this->assertEquals(
+            '?Foobar',
+            (string) $source->classes()->first()->properties()->first()->type()
+        );
+        $this->assertEquals('Bar\Foobar', (string) $source->useStatements()->first());
+    }
+
     public function testSimpleTrait()
     {
         $source = $this->build('<?php trait Foobar {}');
@@ -141,6 +151,12 @@ class WorseBuilderFactoryTest extends TestCase
     {
         $source = $this->build('<?php class Foobar { public function method(string $param) {} }');
         $this->assertEquals('string', (string) $source->classes()->first()->methods()->first()->parameters()->first()->type());
+    }
+
+    public function testMethodWithNullableTypedParameter()
+    {
+        $source = $this->build('<?php class Foobar { public function method(?string $param) {} }');
+        $this->assertEquals('?string', (string) $source->classes()->first()->methods()->first()->parameters()->first()->type());
     }
 
     public function testMethodWithAliasedParameter()

--- a/tests/Adapter/WorseReflection/WorseBuilderFactoryTest.php
+++ b/tests/Adapter/WorseReflection/WorseBuilderFactoryTest.php
@@ -129,6 +129,19 @@ class WorseBuilderFactoryTest extends TestCase
         $this->assertEquals('string', $source->classes()->first()->methods()->first()->returnType());
     }
 
+    public function testMethodWithNullableReturnType()
+    {
+        $source = $this->build('<?php class Foobar { public function method(): ?string {} }');
+        $this->assertEquals('?string', $source->classes()->first()->methods()->first()->returnType());
+    }
+
+    public function testMethodWithImportedNullableReturnType()
+    {
+        $source = $this->build('<?php namespace Test; use Bar\Baz; class Foobar { public function method(): ?Baz {} }');
+        $this->assertEquals('?Baz', $source->classes()->first()->methods()->first()->returnType());
+        $this->assertEquals('Bar\Baz', (string) $source->useStatements()->first());
+    }
+
     public function testMethodProtected()
     {
         $source = $this->build('<?php class Foobar { protected function method() {} }');

--- a/tests/Unit/Util/TextFormatTest.php
+++ b/tests/Unit/Util/TextFormatTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Phpactor\CodeBuilder\Tests\Unit\Util;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\CodeBuilder\Util\TextFormat;
+
+class TextFormatTest extends TestCase
+{
+    public function testThatItDoesNotIndentBlankLines()
+    {
+        $input = <<<EOT
+Non blank line
+
+Non blank line
+EOT;
+        $expectedOutput = <<<EOT
+    Non blank line
+
+    Non blank line
+EOT;
+
+        $formater = new TextFormat('    ');
+        $this->assertSame($expectedOutput, $formater->indent($input, 1));
+    }
+
+    public function testThatItIndentOnMoreThanOneLevel()
+    {
+        $input = <<<EOT
+Non blank line
+
+Non blank line
+EOT;
+        $expectedOutput = <<<EOT
+        Non blank line
+
+        Non blank line
+EOT;
+
+        $formater = new TextFormat('    ');
+        $this->assertSame($expectedOutput, $formater->indent($input, 2));
+    }
+}


### PR DESCRIPTION
In response to https://github.com/phpactor/phpactor/issues/856

I admit I'm a bit tired right now and extremely hungry so I wont go in too much details.
The goal was to be able to generate typed properties.
In order to be able to keep the old generation and the new one depending on project I had to add a management of template by version of PHP.
I also used the occasion to fix one or two thing in the generation of properties.

I made a lot of commit and I try to rely detail each one of them to explain why and how as much as possible.

There is just one thing, a commit that move a blank line from the `ClassLikeUpdater` class to the `Property.php.twig` template create some "problems" in two situations.
I'm open to discussion about that, it would be nice to find a solution but I think we would have to choose the smaller of two issues :)

- [ ] Add tests for PHP7.4 code generation