### PR TITLE
Code filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "microsoft/tolerant-php-parser": "~0.0.1",
         "twig/twig": "^2.4",
         "phpactor/text-document": "^1.0",
-        "phpactor/worse-reflection": "~0.2"
+        "phpactor/worse-reflection": "~0.2",
+        "symfony/process": "^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0",

--- a/lib/Adapter/Symfony/ProcessFilter.php
+++ b/lib/Adapter/Symfony/ProcessFilter.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Phpactor\CodeBuilder\Adapter\Symfony;
+
+use Phpactor\CodeBuilder\Domain\Code;
+use Phpactor\CodeBuilder\Domain\CodeFilter;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+class ProcessFilter implements CodeFilter
+{
+    /**
+     * @var string
+     */
+    private $binPath;
+
+    /**
+     * @var string
+     */
+    private $commandTemplate;
+
+    public function __construct(string $commandTemplate)
+    {
+        $this->commandTemplate = $commandTemplate;
+    }
+
+    public function filter(Code $code): Code
+    {
+        $tmpName = tempnam(sys_get_temp_dir(), 'phpactor_code_builder');
+
+        if (false === file_put_contents($tmpName, $code->__toString())) {
+            throw new RuntimeException(sprintf(
+                'Could not write to temporary file "%s"',
+                $tmpName
+            ));
+        }
+
+        $command = strtr($this->commandTemplate, [
+            '%file%' => $tmpName
+        ]);
+
+        $process = Process::fromShellCommandline($command);
+        $process->run();
+
+        if (false === $process->isSuccessful()) {
+            throw new RuntimeException(sprintF(
+                'External code filter process failed: "%s"',
+                $process->getErrorOutput()
+            ));
+        }
+
+        return Code::fromString(file_get_contents($tmpName));
+    }
+}

--- a/lib/Domain/CodeFilter.php
+++ b/lib/Domain/CodeFilter.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Phpactor\CodeBuilder\Domain;
+
+interface CodeFilter
+{
+    public function filter(Code $code): Code;
+}

--- a/lib/Domain/CodeFilter/NullCodeFilter.php
+++ b/lib/Domain/CodeFilter/NullCodeFilter.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Phpactor\CodeBuilder\Domain\CodeFilter;
+
+use Phpactor\CodeBuilder\Domain\Code;
+use Phpactor\CodeBuilder\Domain\CodeFilter;
+
+class NullCodeFilter implements CodeFilter
+{
+    public function filter(Code $code): Code
+    {
+        return $code;
+    }
+}

--- a/lib/SourceBuilder.php
+++ b/lib/SourceBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Phpactor\CodeBuilder;
 
+use Phpactor\CodeBuilder\Domain\CodeFilter;
+use Phpactor\CodeBuilder\Domain\CodeFilter\NullCodeFilter;
 use Phpactor\CodeBuilder\Domain\Prototype;
 use Phpactor\CodeBuilder\Domain\Renderer;
 use Phpactor\CodeBuilder\Domain\Updater;
@@ -19,21 +21,28 @@ class SourceBuilder
      */
     private $updater;
 
+    /**
+     * @var CodeFilter
+     */
+    private $filter;
+
     public function __construct(
         Renderer $generator,
-        Updater $updater
+        Updater $updater,
+        CodeFilter $filter = null
     ) {
         $this->generator = $generator;
         $this->updater = $updater;
+        $this->filter = $filter ?: new NullCodeFilter();
     }
 
-    public function render(Prototype\Prototype $prototype)
+    public function render(Prototype\Prototype $prototype): Code
     {
-        return $this->generator->render($prototype);
+        return $this->filter->filter($this->generator->render($prototype));
     }
 
-    public function apply(Prototype\Prototype $prototype, Code $code)
+    public function apply(Prototype\Prototype $prototype, Code $code): Code
     {
-        return $this->updater->apply($prototype, $code);
+        return $this->filter->filter($this->updater->apply($prototype, $code));
     }
 }

--- a/tests/Adapter/UpdaterTestCase.php
+++ b/tests/Adapter/UpdaterTestCase.php
@@ -3,6 +3,7 @@
 namespace Phpactor\CodeBuilder\Tests\Adapter;
 
 use PHPUnit\Framework\TestCase;
+use Phpactor\CodeBuilder\Adapter\Symfony\ProcessFilter;
 use Phpactor\CodeBuilder\Domain\Updater;
 use Phpactor\CodeBuilder\Domain\Code;
 use Phpactor\CodeBuilder\Domain\Builder\SourceCodeBuilder;
@@ -442,13 +443,17 @@ EOT
                 <<<'EOT'
 namespace Animal;
 
-class Foo {}
+class Foo
+{
+}
 EOT
                 , SourceCodeBuilder::create()->use('Animal\Primate')->build()
                 , <<<'EOT'
 namespace Animal;
 
-class Foo {}
+class Foo
+{
+}
 EOT
             ];
     }
@@ -1492,8 +1497,7 @@ class Aardvark
 {
     public function hello(
         array $foobar = []
-    )
-    {
+    ) {
     }
 }
 EOT
@@ -1507,8 +1511,7 @@ class Aardvark
 {
     public function hello(
         array $foobar = []
-    )
-    {
+    ) {
     }
 }
 EOT
@@ -1793,6 +1796,10 @@ EOT
     private function assertUpdate(string $existingCode, SourceCode $prototype, string $expectedCode)
     {
         $code = $this->updater()->apply($prototype, Code::fromString('<?php'.PHP_EOL.$existingCode));
-        $this->assertEquals('<?php' . PHP_EOL . $expectedCode, (string) $code);
+        $filter = new ProcessFilter(
+            __DIR__ . '/../../vendor/bin/php-cs-fixer fix --rules=@PSR2 %file%'
+        );
+        $code = $filter->filter($code);
+        $this->assertEquals('<?php' . PHP_EOL . $expectedCode, trim((string) $code));
     }
 }


### PR DESCRIPTION
This PR would a CodeFilter extension point allowing code to be "filtered" before sending it back.

A `ProcessFilter` is included which filters the code through an external process (such as a CS fixer).

It modifies the tests to filter all generated examples through the `php-cs-fixer`.

It allows the specification of external processes with a command template, e.g. `./vendor/bin/php-cs-fixer fix %file%`

