### PR TITLE
Nullable types

### DIFF
--- a/lib/Adapter/WorseReflection/WorseBuilderFactory.php
+++ b/lib/Adapter/WorseReflection/WorseBuilderFactory.php
@@ -150,6 +150,7 @@ class WorseBuilderFactory implements BuilderFactory
                 $typeName = $alias;
             }
         }
+
         return $typeName;
     }
 }

--- a/templates/Method.php.twig
+++ b/templates/Method.php.twig
@@ -6,4 +6,4 @@
  */
 {% endif %}
 {% if prototype.isAbstract %}abstract {%endif %}{{ prototype.visibility }} {% if prototype.isStatic %}static {%endif %}function {{ prototype.name}}({% spaceless %}
-{% for parameter in prototype.parameters %}{{ generator.render(parameter, variant)|raw }}{% if not loop.last %}, {% endif %}{% endfor %}{% endspaceless %}){% if prototype.returnType.notNone %}: {{ prototype.returnType }}{% endif %}
+{% for parameter in prototype.parameters %}{{ generator.render(parameter, variant)|raw }}{% if not loop.last %}, {% endif %}{% endfor %}{% endspaceless %}){% if prototype.returnType.notNone %}: {{ prototype.returnType.nullable ? '?' : '' }}{{ prototype.returnType }}{% endif %}

--- a/templates/Parameter.php.twig
+++ b/templates/Parameter.php.twig
@@ -1,3 +1,3 @@
-{% if prototype.type.notNone %}{{ prototype.type }} {% endif %}
+{% if prototype.type.notNone %}{{ prototype.type.nullable ? '?' : '' }}{{ prototype.type }} {% endif %}
 {% if prototype.byReference %}&{% endif %}{% if true %}${{ prototype.name }}{% endif %}
 {% if prototype.defaultValue.notNone %} = {{ prototype.defaultValue.export|raw }}{% endif %}

--- a/templates/Property.php.twig
+++ b/templates/Property.php.twig
@@ -1,6 +1,6 @@
 {% if prototype.type.notNone %}
 /**
- * @var {{ prototype.type|trim('?', 'left') }}{{ prototype.type.nullable ? '|null' }}
+ * @var {{ prototype.type }}{{ prototype.type.nullable ? '|null' }}
  */
 {% endif %}
 {{ prototype.visibility }} ${{ prototype.name}}{% if prototype.defaultValue.notNone %} = {{ prototype.defaultValue.export }}{% endif %};

--- a/templates/Property.php.twig
+++ b/templates/Property.php.twig
@@ -1,5 +1,4 @@
 {% if prototype.type.notNone %}
-
 /**
  * @var {{ prototype.type|trim('?', 'left') }}{{ prototype.type.nullable ? '|null' }}
  */

--- a/templates/Property.php.twig
+++ b/templates/Property.php.twig
@@ -1,6 +1,7 @@
 {% if prototype.type.notNone %}
+
 /**
- * @var {{ prototype.type }}
+ * @var {{ prototype.type|trim('?', 'left') }}{{ prototype.type.nullable ? '|null' }}
  */
 {% endif %}
 {{ prototype.visibility }} ${{ prototype.name}}{% if prototype.defaultValue.notNone %} = {{ prototype.defaultValue.export }}{% endif %};

--- a/tests/Adapter/GeneratorTestCase.php
+++ b/tests/Adapter/GeneratorTestCase.php
@@ -244,6 +244,14 @@ EOT
 private function hello($one, string $two, $three = 42)
 EOT
             ],
+            'Renders a method nullable parameter' => [
+                new Method('hello', Visibility::private(), Parameters::fromParameters([
+                    new Parameter('two', Type::fromString('?string')),
+                ])),
+                <<<'EOT'
+private function hello(?string $two)
+EOT
+            ],
             'Renders a method parameter passed as a reference' => [
                 new Method('hello', Visibility::private(), Parameters::fromParameters([
                     new Parameter('three', Type::none(), DefaultValue::none(), true),
@@ -317,6 +325,17 @@ EOT
                 ),
                 <<<'EOT'
 private function hello(): Hello
+EOT
+            ],
+            'Renders method nullable return type' => [
+                new Method(
+                    'hello',
+                    Visibility::private(),
+                    Parameters::empty(),
+                    ReturnType::fromString('?Hello')
+                ),
+                <<<'EOT'
+private function hello(): ?Hello
 EOT
             ],
             'Renders a class with a parent' => [

--- a/tests/Adapter/UpdaterTestCase.php
+++ b/tests/Adapter/UpdaterTestCase.php
@@ -965,7 +965,6 @@ EOT
                 <<<'EOT'
 class Aardvark
 {
-
     /**
      * @var Hello
      */
@@ -1133,7 +1132,6 @@ EOT
                 <<<'EOT'
 trait Aardvark
 {
-
     /**
      * @var Hello
      */

--- a/tests/Adapter/UpdaterTestCase.php
+++ b/tests/Adapter/UpdaterTestCase.php
@@ -7,6 +7,7 @@ use Phpactor\CodeBuilder\Domain\Updater;
 use Phpactor\CodeBuilder\Domain\Code;
 use Phpactor\CodeBuilder\Domain\Builder\SourceCodeBuilder;
 use Phpactor\CodeBuilder\Domain\Prototype\SourceCode;
+use Phpactor\WorseReflection\Core\Type;
 
 abstract class UpdaterTestCase extends TestCase
 {
@@ -895,7 +896,7 @@ class Aardvark
 EOT
             ];
 
-        yield 'It adds a documented properties' => [
+        yield 'It adds a typed property' => [
                 <<<'EOT'
 class Aardvark
 {
@@ -920,6 +921,33 @@ class Aardvark
 EOT
             ];
 
+        yield 'It adds a nullable typed property' => [
+                <<<'EOT'
+class Aardvark
+{
+    public $eyes
+}
+EOT
+                , SourceCodeBuilder::create()
+                    ->class('Aardvark')
+                        ->property('propertyOne')->type(
+                            Type::fromString('Hello')->asNullable()
+                        )->end()
+                    ->end()
+                    ->build(),
+                <<<'EOT'
+class Aardvark
+{
+    public $eyes
+
+    /**
+     * @var Hello|null
+     */
+    public $propertyOne;
+}
+EOT
+            ];
+
         yield 'It adds before methods' => [
                 <<<'EOT'
 class Aardvark
@@ -937,6 +965,7 @@ EOT
                 <<<'EOT'
 class Aardvark
 {
+
     /**
      * @var Hello
      */
@@ -1104,6 +1133,7 @@ EOT
                 <<<'EOT'
 trait Aardvark
 {
+
     /**
      * @var Hello
      */
@@ -1276,6 +1306,35 @@ EOT
 class Aardvark
 {
     public function methodOne(Barf $sniff)
+    {
+    }
+}
+EOT
+            ];
+
+        yield 'It adds nullable typed parameters' => [
+                <<<'EOT'
+class Aardvark
+{
+    public function methodOne()
+    {
+    }
+}
+EOT
+                , SourceCodeBuilder::create()
+                    ->class('Aardvark')
+                        ->method('methodOne')
+                            ->parameter('sniff')->type(
+                                Type::fromString('Barf')->asNullable()
+                            )
+                            ->end()
+                        ->end()
+                    ->end()
+                    ->build(),
+                <<<'EOT'
+class Aardvark
+{
+    public function methodOne(?Barf $sniff)
     {
     }
 }


### PR DESCRIPTION
Partially cherry-picked from #14 . Note that adding `?` to the types `__toString` has a sideeffect as it is used f.e. in class imports - it was removed from `master`.