### PR TITLE
Fix extra new line when adding a use statement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Generating and modifying source code",
     "license": "MIT",
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "authors": [
         {
             "name": "Daniel Leech",

--- a/tests/Adapter/UpdaterTestCase.php
+++ b/tests/Adapter/UpdaterTestCase.php
@@ -95,24 +95,30 @@ EOT
         yield 'It adds use statements' => [
 
                 <<<'EOT'
+$bovine = new Bovine();
 EOT
                 , SourceCodeBuilder::create()->use('Foo\Bovine')->build(),
                 <<<'EOT'
 
 use Foo\Bovine;
 
+$bovine = new Bovine();
 EOT
             ];
 
         yield 'It adds use statements with an alias' => [
 
                 <<<'EOT'
+// test
+$bovine = new Bovine();
 EOT
                 , SourceCodeBuilder::create()->use('Foo\Bovine', 'Cow')->build(),
                 <<<'EOT'
 
 use Foo\Bovine as Cow;
 
+// test
+$bovine = new Bovine();
 EOT
             ];
 
@@ -121,12 +127,16 @@ EOT
                 <<<'EOT'
 use Foo\Dino;
 
+// test
+$bovine = new Bovine();
 EOT
                 , SourceCodeBuilder::create()->use('Foo\Bovine', 'Cow')->build(),
                 <<<'EOT'
 use Foo\Bovine as Cow;
 use Foo\Dino;
 
+// test
+$bovine = new Bovine();
 EOT
             ];
 
@@ -134,12 +144,16 @@ EOT
 
                 <<<'EOT'
 namespace Kingdom;
+
+$bovine = new Bovine();
 EOT
                 , SourceCodeBuilder::create()->use('Bovine')->build(),
                 <<<'EOT'
 namespace Kingdom;
 
 use Bovine;
+
+$bovine = new Bovine();
 EOT
             ];
 
@@ -402,24 +416,29 @@ EOT
         yield 'It adds use function statements' => [
 
                 <<<'EOT'
+hello('you');
 EOT
                 , SourceCodeBuilder::create()->useFunction('Foo\hello')->build(),
                 <<<'EOT'
 
 use function Foo\hello;
 
+hello('you');
 EOT
             ];
 
         yield 'It adds use function statements with an alias' => [
 
                 <<<'EOT'
+
+hello('you');
 EOT
                 , SourceCodeBuilder::create()->useFunction('Foo\hello', 'bar')->build(),
                 <<<'EOT'
 
 use function Foo\hello as bar;
 
+hello('you');
 EOT
             ];
 
@@ -427,11 +446,15 @@ EOT
 
                 <<<'EOT'
 use function Foo\hello as boo;
+
+hello('you');
 EOT
                 , SourceCodeBuilder::create()->useFunction('Foo\hello', 'bar')->build(),
                 <<<'EOT'
 use function Foo\hello as boo;
 use function Foo\hello as bar;
+
+hello('you');
 EOT
             ];
 
@@ -439,10 +462,14 @@ EOT
 
                 <<<'EOT'
 use function Foo\hello as boo;
+
+hello('you');
 EOT
                 , SourceCodeBuilder::create()->useFunction('Foo\hello', 'boo')->build(),
                 <<<'EOT'
 use function Foo\hello as boo;
+
+hello('you');
 EOT
             ];
 
@@ -452,6 +479,8 @@ EOT
 use Foobar\Acme;
 use Foobar\Hello;
 use Foobar\Zoo;
+
+hello('you');
 EOT
                 , SourceCodeBuilder::create()->useFunction('Foobar\Bello')->build(),
                 <<<'EOT'
@@ -459,6 +488,8 @@ use Foobar\Acme;
 use Foobar\Hello;
 use Foobar\Zoo;
 use function Foobar\Bello;
+
+hello('you');
 EOT
             ];
     }


### PR DESCRIPTION
That's an issue I had at work for quite a while and I had it when fixing: https://github.com/phpactor/phpactor/issues/1106

I added some cases to the tests to reproduce the bug and fixed it.
For my understanding the issue came from the `NodeHelper::emptyLinesPrecedingNode()` method.
This method was returning `0` which triggers the add of a new line the following case:
```php
<?php

use SomeClass;

// Comment
$nodeForWhichWeLookForPrecedingEmptyLines = 'something';
```
Resulting in:
```php
<?php

use NewlyAddedUseStatement;
use SomeClass;


// Comment
$nodeForWhichWeLookForPrecedingEmptyLines = 'something';
```

This is because the helper check the number of empty lines between the node (last line) and the comment above.

In order to solve the issue I decided to only do this check when adding imports to a code that has none.
Meaning if we add an import to a code like:
```php
<?php

use SomeClass;
$restOfTheCode = 'test';
```
The result will be:
```php
<?php

use NewlyAddedUseStatement;
use SomeClass;
$restOfTheCode = 'test';
```

I'm personally fine with it, I think the codebuilder should try to follow the PSR as much as possible but it should not change the code it does not generate itself.
If a user has some really strange rules for their code base (we have some really disturbing at work for exmaple...) phpactor should not try to fix it by itself.

Bottom line:
- If there is no use statements, then we do things following the PSR and add a blank line before and after the uses
- If there is already some use statements, then we simply add in the right position inside the exising block without interfering more than that

Is this a policy you can accept or do you prefer for the code builder to also fix the code when it can ?

P.S.: I added the `prefer-stable: true` to the `composer.json`, tell me if you want me to remove it.